### PR TITLE
Add dual microphone support

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,6 +128,21 @@
             margin-bottom: 30px;
         }
 
+        .device-selectors {
+            display: flex;
+            gap: 15px;
+            justify-content: center;
+            margin-bottom: 20px;
+        }
+
+        .device-selectors select {
+            padding: 8px 12px;
+            background: #333;
+            color: #fff;
+            border: none;
+            border-radius: 5px;
+        }
+
         button {
             background: linear-gradient(45deg, #667eea 0%, #764ba2 100%);
             color: white;
@@ -302,6 +317,15 @@
             <button id="testB" disabled>Test Peak B</button>
         </div>
 
+        <div class="device-selectors">
+            <label>Mic A:
+                <select id="micSelectA"></select>
+            </label>
+            <label>Mic B:
+                <select id="micSelectB"></select>
+            </label>
+        </div>
+
         <div id="statusMessage" class="status-message"></div>
 
         <div class="control-panel">
@@ -454,7 +478,11 @@
         // Audio context and nodes
         let audioContext;
         let isRunning = false;
-        let micStream = null;
+        let micStreamA = null;
+        let micStreamB = null;
+
+        let selectedDeviceIdA = null;
+        let selectedDeviceIdB = null;
 
         // Audio nodes for Umwelt A
         let sourceA, analyserA, filterA, gainA, pannerA;
@@ -490,6 +518,43 @@
             PRE_KNOT_GAIN: 0.7,
             KNOT_FX_GAIN: 0.3
         };
+
+        async function populateDeviceSelectors() {
+            try {
+                const devices = await navigator.mediaDevices.enumerateDevices();
+                const audioInputs = devices.filter(d => d.kind === 'audioinput');
+
+                const selectA = document.getElementById('micSelectA');
+                const selectB = document.getElementById('micSelectB');
+                selectA.innerHTML = '';
+                selectB.innerHTML = '';
+
+                audioInputs.forEach((device, index) => {
+                    const optionA = document.createElement('option');
+                    optionA.value = device.deviceId;
+                    optionA.textContent = device.label || `Microphone ${index + 1}`;
+                    selectA.appendChild(optionA);
+
+                    const optionB = optionA.cloneNode(true);
+                    selectB.appendChild(optionB);
+                });
+
+                if (audioInputs.length > 0) {
+                    selectedDeviceIdA = selectA.value;
+                    selectedDeviceIdB = audioInputs[1] ? selectB.options[1].value : selectA.value;
+                    selectB.value = selectedDeviceIdB;
+                }
+
+                selectA.addEventListener('change', e => {
+                    selectedDeviceIdA = e.target.value;
+                });
+                selectB.addEventListener('change', e => {
+                    selectedDeviceIdB = e.target.value;
+                });
+            } catch (err) {
+                console.error('Failed to enumerate devices', err);
+            }
+        }
 
         // Heartbeat detector class
         class HeartbeatDetector {
@@ -539,6 +604,8 @@
         async function initAudio() {
             try {
                 audioContext = new (window.AudioContext || window.webkitAudioContext)();
+
+                await populateDeviceSelectors();
                 
                 // Create master gain and fx gain
                 masterGain = audioContext.createGain();
@@ -622,14 +689,15 @@
             
             // Try to get microphone input
             try {
-                const stream = await navigator.mediaDevices.getUserMedia({ 
+                const stream = await navigator.mediaDevices.getUserMedia({
                     audio: {
+                        deviceId: selectedDeviceIdA ? { exact: selectedDeviceIdA } : undefined,
                         echoCancellation: false,
                         noiseSuppression: false,
                         autoGainControl: false
-                    } 
+                    }
                 });
-                micStream = stream;
+                micStreamA = stream;
                 sourceA = audioContext.createMediaStreamSource(stream);
                 sourceA.connect(filterA);
                 updateStatus('Microphone A connected', 'success');
@@ -696,16 +764,27 @@
             // Start drone
             droneOscB.start();
             
-            // For Umwelt B, we'll use the same microphone input but process it differently
-            // In a real two-person setup, you would have two separate microphones
-            if (micStream) {
-                // If we successfully got microphone for A, reuse the same stream
-                sourceB = audioContext.createMediaStreamSource(micStream);
+            // Attempt to use a second microphone if available
+            try {
+                let stream;
+                if (selectedDeviceIdB === selectedDeviceIdA && micStreamA) {
+                    stream = micStreamA;
+                } else {
+                    stream = await navigator.mediaDevices.getUserMedia({
+                        audio: {
+                            deviceId: selectedDeviceIdB ? { exact: selectedDeviceIdB } : undefined,
+                            echoCancellation: false,
+                            noiseSuppression: false,
+                            autoGainControl: false
+                        }
+                    });
+                    micStreamB = stream;
+                }
+                sourceB = audioContext.createMediaStreamSource(stream);
                 sourceB.connect(filterB);
-            } else {
-                // Fallback to test oscillator
+            } catch (error) {
                 const testOsc = audioContext.createOscillator();
-                testOsc.frequency.value = 1.3; // Simulate 78 BPM heartbeat
+                testOsc.frequency.value = 1.3;
                 const testGain = audioContext.createGain();
                 testGain.gain.value = 0;
                 testOsc.connect(testGain);
@@ -972,10 +1051,15 @@
         function stopAudio() {
             isRunning = false;
             
-            // Stop microphone stream
-            if (micStream) {
-                micStream.getTracks().forEach(track => track.stop());
-                micStream = null;
+            // Stop microphone streams
+            const msA = micStreamA;
+            if (msA) {
+                msA.getTracks().forEach(track => track.stop());
+                micStreamA = null;
+            }
+            if (micStreamB && micStreamB !== msA) {
+                micStreamB.getTracks().forEach(track => track.stop());
+                micStreamB = null;
             }
             
             if (audioContext) {
@@ -1102,6 +1186,8 @@
 
         window.addEventListener('resize', resizeCanvases);
         resizeCanvases();
+
+        populateDeviceSelectors();
 
         // Display initial status
         updateStatus('Click "Start Audio" to begin the experience');


### PR DESCRIPTION
## Summary
- support choosing two different microphones by listing audio input devices
- init each Umwelt with the selected device
- handle stopping multiple input streams

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f042008e08330955dd468b56c00ff