### PR TITLE
Add remote BPM mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,6 +142,19 @@
             border: none;
             border-radius: 5px;
         }
+        .remote-bpm {
+            display: flex;
+            gap: 10px;
+            justify-content: center;
+            margin-bottom: 20px;
+        }
+        .remote-bpm input[type="text"] {
+            padding: 8px 12px;
+            background: #333;
+            color: #fff;
+            border: none;
+            border-radius: 5px;
+        }
         .speaker-selectors {
             display: flex;
             flex-wrap: wrap;
@@ -355,6 +368,12 @@
             <label>Mic B:
                 <select id="micSelectB"></select>
             </label>
+        </div>
+        <div class="remote-bpm">
+            <label style="display:flex;align-items:center;gap:5px;">
+                <input type="checkbox" id="useRemoteBpmB">Use Remote BPM for B
+            </label>
+            <input type="text" id="remoteBpmUrl" placeholder="API URL">
         </div>
         <div class="speaker-selectors">
             <label>Speaker 1:
@@ -818,6 +837,12 @@
         let outputNodes = [];
         let outputAudios = [];
 
+        // Remote BPM settings
+        let useRemoteBpmB = false;
+        let remoteBpmUrl = '';
+        let remoteBpm = 0;
+        let remoteBpmInterval = null;
+
 
         // Test mode flag
         let isTestMode = false;
@@ -827,6 +852,23 @@
             return Math.pow(10, db / 20);
         }
         let micMonitorEnabled = false;
+
+        async function fetchRemoteBpm() {
+            if (!useRemoteBpmB || !remoteBpmUrl) return;
+            try {
+                const response = await fetch(remoteBpmUrl);
+                const data = await response.json();
+                if (Array.isArray(data) && data.length > 1) {
+                    const last = data[data.length - 1];
+                    const bpmVal = parseFloat(last[1]);
+                    if (!isNaN(bpmVal)) {
+                        remoteBpm = bpmVal;
+                    }
+                }
+            } catch (err) {
+                console.error('Error fetching remote BPM:', err);
+            }
+        }
 
         // Parameters
         const params = {
@@ -1185,10 +1227,19 @@
             // Start drone
             droneOscB.start();
             
-            // Attempt to use a second microphone if available
-            try {
-                let stream;
-                if (selectedDeviceIdB === selectedDeviceIdA && micStreamA) {
+            if (useRemoteBpmB) {
+                const silentOsc = audioContext.createOscillator();
+                const silentGain = audioContext.createGain();
+                silentGain.gain.value = 0;
+                silentOsc.connect(silentGain);
+                silentGain.connect(filterB);
+                silentOsc.start();
+                sourceB = silentGain;
+            } else {
+                // Attempt to use a second microphone if available
+                try {
+                    let stream;
+                    if (selectedDeviceIdB === selectedDeviceIdA && micStreamA) {
                     stream = micStreamA;
 
                     if (!channelSplitter) {
@@ -1232,15 +1283,16 @@
                     micFilterB.connect(micGainB);
                     micGainB.connect(pannerB);
                 }
-            } catch (error) {
-                const testOsc = audioContext.createOscillator();
-                testOsc.frequency.value = 1.3;
-                const testGain = audioContext.createGain();
-                testGain.gain.value = 0;
-                testOsc.connect(testGain);
-                testGain.connect(filterB);
-                testOsc.start();
-                sourceB = testGain;
+                } catch (error) {
+                    const testOsc = audioContext.createOscillator();
+                    testOsc.frequency.value = 1.3;
+                    const testGain = audioContext.createGain();
+                    testGain.gain.value = 0;
+                    testOsc.connect(testGain);
+                    testGain.connect(filterB);
+                    testOsc.start();
+                    sourceB = testGain;
+                }
             }
         }
 
@@ -1327,7 +1379,11 @@
             const dataArrayB = new Uint8Array(bufferLength);
             
             analyserA.getByteTimeDomainData(dataArrayA);
-            analyserB.getByteTimeDomainData(dataArrayB);
+            if (!useRemoteBpmB) {
+                analyserB.getByteTimeDomainData(dataArrayB);
+            } else {
+                dataArrayB.fill(128);
+            }
             
             // Calculate amplitudes
             let maxA = 0, maxB = 0;
@@ -1337,11 +1393,14 @@
                 if (valA > maxA) maxA = valA;
                 if (valB > maxB) maxB = valB;
             }
+            if (useRemoteBpmB) maxB = 0;
             
             // Detect peaks
             const currentTime = Date.now();
             const resultA = detectorA.detectPeak(maxA, currentTime);
-            const resultB = detectorB.detectPeak(maxB, currentTime);
+            const resultB = useRemoteBpmB
+                ? { isNewPeak: false, bpm: remoteBpm, peak: 0 }
+                : detectorB.detectPeak(maxB, currentTime);
             
             // Update global data
             window.audioAnalysisData.A = {
@@ -1511,6 +1570,11 @@
                 micStreamB.getTracks().forEach(track => track.stop());
                 micStreamB = null;
             }
+
+            if (remoteBpmInterval) {
+                clearInterval(remoteBpmInterval);
+                remoteBpmInterval = null;
+            }
             
             if (audioContext) {
                 audioContext.close();
@@ -1581,6 +1645,22 @@
             micMonitorEnabled = e.target.checked;
             if (micGainA) micGainA.gain.value = micMonitorEnabled ? dBToAmp(params.MIC_MONITOR_GAIN_DB) : 0;
             if (micGainB) micGainB.gain.value = micMonitorEnabled ? dBToAmp(params.MIC_MONITOR_GAIN_DB) : 0;
+        });
+
+        document.getElementById('useRemoteBpmB').addEventListener('change', e => {
+            useRemoteBpmB = e.target.checked;
+            remoteBpmUrl = document.getElementById('remoteBpmUrl').value.trim();
+            if (useRemoteBpmB) {
+                fetchRemoteBpm();
+                remoteBpmInterval = setInterval(fetchRemoteBpm, 10000);
+            } else {
+                remoteBpm = 0;
+                if (remoteBpmInterval) clearInterval(remoteBpmInterval);
+            }
+        });
+
+        document.getElementById('remoteBpmUrl').addEventListener('change', e => {
+            remoteBpmUrl = e.target.value.trim();
         });
 
         // Parameter controls
@@ -1673,6 +1753,13 @@
         resizeCanvases();
 
         populateDeviceSelectors();
+
+        if (document.getElementById('useRemoteBpmB').checked) {
+            useRemoteBpmB = true;
+            remoteBpmUrl = document.getElementById('remoteBpmUrl').value.trim();
+            fetchRemoteBpm();
+            remoteBpmInterval = setInterval(fetchRemoteBpm, 10000);
+        }
 
         // Display initial status
         updateStatus('Click "Start Audio" to begin the experience');


### PR DESCRIPTION
## Summary
- implement remote BPM option that replaces microphone B with an API source
- style and UI updates for the new checkbox and API URL field
- fetch BPM from the specified API and apply it when enabled

## Testing
- `node -e "require('fs').readFileSync('index.html')"`

------
https://chatgpt.com/codex/tasks/task_e_684f3a0fcac48330b8c7120ad408eac8