### PR TITLE
Fix device selection reset when starting audio

### DIFF
--- a/index.html
+++ b/index.html
@@ -890,7 +890,9 @@
         };
 
 
-        async function populateDeviceSelectors() {
+        async function populateDeviceSelectors(preserveSelections = false) {
+            const prevA = selectedDeviceIdA;
+            const prevB = selectedDeviceIdB;
             try {
                 const devices = await navigator.mediaDevices.enumerateDevices();
                 const audioInputs = devices.filter(d => d.kind === 'audioinput');
@@ -916,9 +918,17 @@
                 });
 
                 if (audioInputs.length > 0) {
+                    if (preserveSelections && prevA && [...selectA.options].some(o => o.value === prevA)) {
+                        selectA.value = prevA;
+                    }
                     selectedDeviceIdA = selectA.value;
-                    selectedDeviceIdB = audioInputs[1] ? selectB.options[1].value : selectA.value;
-                    selectB.value = selectedDeviceIdB;
+
+                    if (preserveSelections && prevB && [...selectB.options].some(o => o.value === prevB)) {
+                        selectB.value = prevB;
+                    } else {
+                        selectB.value = audioInputs[1] ? selectB.options[1].value : selectA.value;
+                    }
+                    selectedDeviceIdB = selectB.value;
                 }
 
                 speakerSelects.forEach((select, idx) => {
@@ -1058,7 +1068,7 @@
             try {
                 audioContext = new (window.AudioContext || window.webkitAudioContext)();
 
-                await populateDeviceSelectors();
+                await populateDeviceSelectors(true);
                 
                 // Create master gain and fx gain
                 masterGain = audioContext.createGain();


### PR DESCRIPTION
## Summary
- avoid resetting selected microphone and speaker devices when starting audio
- preserve previously selected IDs in `populateDeviceSelectors`

## Testing
- `tidy` *(fails: command not found)*
- `htmlhint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f3b14becc83308518e11cdc01ed0d